### PR TITLE
Fix interpolation

### DIFF
--- a/.changeset/many-cooks-play.md
+++ b/.changeset/many-cooks-play.md
@@ -1,0 +1,5 @@
+---
+"hue-map": patch
+---
+
+Fix interpolation of maps with more points than steps requested. Also ensures that the last colour is always the end-most colour from the map.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ const myPalette = createPalette({
 })
 
 console.log(myPalette)
-// ['#472C7AFF', '#2C718EFF', '#5CC863FF']
+// ['#440154FF', '#21908DFF', '#FDE725FF']
 ```
 
 ## API

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Interpolate gradients based on common palettes. **[See a demo](https://giraugh.g
 
 Inspired by D3 colour scales, with maps from [colormap](https://github.com/bpostlethwaite/colormap).
 
+![Some example palettes](https://user-images.githubusercontent.com/8862273/185757207-643934bb-da49-42f6-9956-8185de6bcb19.png)
+
 ## Installation
 
 ```bash

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -13,7 +13,7 @@ type CreatePaletteOptions = {
 /**
  * Generate a palette from a given color map.
  * @param {ColorMapInput} options.map The name of the colormap to use, or a custom map.
- * @param {number} options.steps The number of steps to include in the palette. Must be greater than or equal to number of points in color map.
+ * @param {number} options.steps The number of steps to include in the palette.
  * @param {PaletteFormat} options.format The format of the palette colors.
  * @returns {Palette} The generated palette.
  */

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -23,14 +23,19 @@ export const createPalette = ({ map = 'viridis', steps = 10, format = 'cssHex' }
 
   // Map colour points from 0..1 to steps array
   const colorPoints = colorMap.map(([index, color]) => ({
-    index: Math.round(index * steps),
+    index: Math.round(index * (steps-1)),
     color: typeof color === 'number' ? hexColorToRGBA(color) : color,
-  }))
+  })).filter(({ index }, i, all) => {
+    if (index === steps-1) return all.filter((p, j) => p.index === index && j > i).length < 1
+    return all.findIndex(p => p.index === index) === i
+  })
 
   // Create colors
   const colorsRGBA = colorPoints
-    .filter((_, i) => i < colorPoints.length - 1)
     .flatMap((_, i) => {
+      // If this is the last point in the array, just return it
+      if (i === colorPoints.length-1) return [colorPoints[i].color]
+
       // Compare this point to the next point
       //  - how far is it (in steps)
       //  - how does the colour change

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -23,7 +23,7 @@ describe('convertRGBA', () => {
 describe('createPalette', () => {
   it('creates the correct palette using default arguments', () => {
     expect(createPalette())
-      .toStrictEqual(['#440154FF','#472C7AFF','#413F83FF','#3B518BFF','#2C718EFF','#21908DFF','#27AD81FF','#42BB72FF','#5CC863FF','#AADC32FF'])
+      .toStrictEqual(['#440154FF','#472C7AFF','#3B518BFF','#2C718EFF','#27818EFF','#21908DFF','#27AD81FF','#5CC863FF','#AADC32FF','#FDE725FF'])
   })
 
   it('creates the correct number of color steps', () => {
@@ -34,17 +34,17 @@ describe('createPalette', () => {
 
   it('creates the correct palette', () => {
     expect(createPalette({ map: 'jet', steps: 5 }))
-      .toStrictEqual(['#000083FF','#003CAAFF','#05FFFFFF','#FFFF00FF','#FA0000FF'])
+      .toStrictEqual(['#000083FF','#003CAAFF','#05FFFFFF','#FFFF00FF','#800000FF'])
   })
 
   it('correctly interpolates alpha', () => {
     expect(createPalette({ map: 'alpha', steps: 5 }))
-      .toStrictEqual(['#FFFFFF00','#FFFFFF33','#FFFFFF66','#FFFFFF99','#FFFFFFCC'])
+      .toStrictEqual(['#FFFFFF00','#FFFFFF40','#FFFFFF80','#FFFFFFBF','#FFFFFFFF'])
   })
 
   it('returns the correct color format', () => {
     expect(createPalette({ map: 'plasma', steps: 5, format: 'number' }))
-      .toStrictEqual([0x0D0887FF,0x7D03A8FF,0xA82296FF,0xE56B5DFF,0xFDC328FF])
+      .toStrictEqual([0x0D0887FF,0x7D03A8FF,0xCB4679FF,0xF89441FF,0xF0F921FF])
   })
 
   it('supports custom color maps', () => {
@@ -52,12 +52,12 @@ describe('createPalette', () => {
       map: [[0, 0xFEAC5EFF],[0.5, 0xC779D0FF],[1, 0x4BC0C8FF]],
       steps: 5,
       format: 'number',
-    })).toStrictEqual([0xFEAC5EFF,0xEC9B84FF,0xD98AAAFF,0xC779D0FF,0x899DCCFF])
+    })).toStrictEqual([0xFEAC5EFF,0xE39397FF,0xC779D0FF,0x899DCCFF,0x4BC0C8FF])
 
     expect(createPalette({
       map: [[0, [38, 83, 43, 255]],[0.25, [57, 158, 90, 255]],[0.5, [90, 188, 185, 255]],[0.75, [99, 226, 198, 255]],[1, [110, 249, 245, 255]]],
       steps: 5,
       format: 'number',
-    })).toStrictEqual([0x26532BFF,0x399E5AFF,0x4AAD8AFF,0x5ABCB9FF,0x63E2C6FF])
+    })).toStrictEqual([0x26532BFF,0x399E5AFF,0x5ABCB9FF,0x63E2C6FF,0x6EF9F5FF])
   })
 })

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -7,6 +7,8 @@ describe('lerp', () => {
     expect(lerp(0, 1, .5)).toBe(.5)
     expect(lerp(-10, 0, .5)).toBe(-5)
     expect(lerp(0, .5, Math.PI)).toBe(Math.PI/2)
+    expect(lerp(0, 255, 0)).toBe(0)
+    expect(lerp(0, 255, 1)).toBe(255)
   })
 })
 


### PR DESCRIPTION
Fixes #4 

This PR fixes the interpolation when requesting less steps than what exist in the colour map being used. If 1 step is requested, it will now always return the colour at index `0`.

I will admit that the code I'm using to achieve this is less than ideal, but it produces nice results. If a way of arriving at the same values with more concise code is possible, I welcome any suggestions or changes.