### PR TITLE
Refactor API to return Palette Object

### DIFF
--- a/.changeset/selfish-grapes-melt.md
+++ b/.changeset/selfish-grapes-melt.md
@@ -1,5 +1,5 @@
 ---
-"hue-map": minor
+"hue-map": major
 ---
 
 Refactor api to return a palette object which can be formatted later

--- a/.changeset/selfish-grapes-melt.md
+++ b/.changeset/selfish-grapes-melt.md
@@ -1,0 +1,5 @@
+---
+"hue-map": minor
+---
+
+Refactor api to return a palette object which can be formatted later

--- a/README.md
+++ b/README.md
@@ -18,21 +18,20 @@ yarn add hue-map
 ## Usage
 
 ```js
-import createPalette from 'hue-map'
+import { createPalette } from 'hue-map'
 
 const myPalette = createPalette({
   map: 'viridis',
   steps: 3,
-  format: 'cssHex',
 })
 
-console.log(myPalette)
-// ['#440154FF', '#21908DFF', '#FDE725FF']
+console.log(myPalette.format('cssHex'))
+// --> ['#440154FF', '#21908DFF', '#FDE725FF']
 ```
 
 ## API
 
-The default export is a function that takes an options object.
+The `createPalette` export is a function that takes an options object.
 
 ### Options
 
@@ -55,7 +54,7 @@ Visit the [demo page](https://giraugh.github.io/hue-map/) to see a list with exa
 You can also provide a custom colour map to the `map` option, with a type of `[number, number | RGBA][]`. This is an array of tuples, where each tuple has an index of where that colour appears in the gradient (from 0 to 1), and the colour at that point, as a HEX number or an RGBA tuple. Note that all HEX numbers need to include alpha.
 
 ```js
-import createPalette from 'hue-map'
+import { createPalette } from 'hue-map'
 
 // 3 colour points, using HEX values
 const myHexPalette = createPalette({

--- a/README.md
+++ b/README.md
@@ -31,15 +31,28 @@ console.log(myPalette.format('cssHex'))
 
 ## API
 
-The `createPalette` export is a function that takes an options object.
+`hue-map` exports a `createPalette` function which takes an options object and returns a palette object.
 
-### Options
+### Palette Creation Options 
 
 | Property | Type | Default | Description |
 | -------- | ---- | ------- | ----------- |
 | `map` | `string` | `'viridis'` | The colour map to use, see below for a list of built-in colour maps. You can also provide a custom colour map. |
 | `steps` | `number` | `10` | The number of colour shades to return. |
-| `format` | `'float' \| 'rgba' \| 'cssHex' \| 'cssRGBA' \| 'number'` | `'cssHex'` | The format of the returned colours. E.g. `float` for `[0.96, 0.61, 0, 1]`, `rgba` for `[247, 158, 0, 1]`, `cssHex` for `'#F79E00FF'`, `cssRGBA` for `'rgba(247, 158, 0, 1)'`, and `number` for `0xF79E00FF` (or `4154327295` in base 10). |
+
+
+### Palette Formatting
+
+Call `.format()` on a palette object to get an array of colours. Pass a `format` argument to control the format that the colors are returned as.
+
+| Format   | Returned Type | Example     | Description                                 |
+| -------- | ------------- | ----------- | ------------------------------------------- |
+| `cssHex` | `string`      | `'#F79E00FF'` | A valid css colour in the form of #RRGGBBAA |
+| `cssRGBA` | `string`      | `'rgba(247, 158, 0, 1)'` | A valid css colour in the form of rgba(R, G, B, A) |
+| `number` | `number`      | `0xF79E00FF` | A hex number representing the colour in the form of 0xRRGGBBAA |
+| `float` | `[number, number, number, number]` | A four-tuple of numbers between 0 and 1 representing R, G, B, and A respectively |
+| `rgba` | `[number, number, number, number]` | A four-tuple of numbers between 0 and 255 representing R, G, B, and A respectively |
+
 
 ### Built-in maps
 

--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ Call `.format()` on a palette object to get an array of colours. Pass a `format`
 | `cssHex` | `string`      | `'#F79E00FF'` | A valid css colour in the form of #RRGGBBAA |
 | `cssRGBA` | `string`      | `'rgba(247, 158, 0, 1)'` | A valid css colour in the form of rgba(R, G, B, A) |
 | `number` | `number`      | `0xF79E00FF` | A hex number representing the colour in the form of 0xRRGGBBAA |
-| `float` | `[number, number, number, number]` | A four-tuple of numbers between 0 and 1 representing R, G, B, and A respectively |
-| `rgba` | `[number, number, number, number]` | A four-tuple of numbers between 0 and 255 representing R, G, B, and A respectively |
+| `float` | `[number, number, number, number]` | [0.3, 0.2, 0.5, 1.0]  | A four-tuple of numbers between 0 and 1 representing R, G, B, and A respectively |
+| `rgba` | `[number, number, number, number]` |  [128, 40, 200, 255] | A four-tuple of numbers between 0 and 255 representing R, G, B, and A respectively |
 
 
 ### Built-in maps

--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ Call `.format()` on a palette object to get an array of colours. Pass a `format`
 | `cssHex` | `string`      | `'#F79E00FF'` | A valid css colour in the form of #RRGGBBAA |
 | `cssRGBA` | `string`      | `'rgba(247, 158, 0, 1)'` | A valid css colour in the form of rgba(R, G, B, A) |
 | `number` | `number`      | `0xF79E00FF` | A hex number representing the colour in the form of 0xRRGGBBAA |
-| `float` | `[number, number, number, number]` | [0.3, 0.2, 0.5, 1.0]  | A four-tuple of numbers between 0 and 1 representing R, G, B, and A respectively |
-| `rgba` | `[number, number, number, number]` |  [128, 40, 200, 255] | A four-tuple of numbers between 0 and 255 representing R, G, B, and A respectively |
+| `float` | `[number, number, number, number]` | `[0.3, 0.2, 0.5, 1.0]`  | A four-tuple of numbers between 0 and 1 representing R, G, B, and A respectively |
+| `rgba` | `[number, number, number, number]` | `[128, 40, 200, 255]` | A four-tuple of numbers between 0 and 255 representing R, G, B, and A respectively |
 
 
 ### Built-in maps

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,5 +1,5 @@
 import maps, { ColorMap, MapKey } from './maps'
-import { hexColorToRGBA, lerpRGBA, RGBA } from './util'
+import { hexColorToRGBA, lerpRGBA, RGBA, RGBAFloat } from './util'
 
 export type ColorMapInput = MapKey | ColorMap
 export type PaletteFormat = 'float' | 'rgba' | 'cssHex' | 'cssRGBA' | 'number'
@@ -16,12 +16,12 @@ class Palette {
   }
 
   /** Convert this palette into a specified format */
-  format(_format: 'cssHex'): string[]
   format(_format: 'cssRGBA'): string[]
   format(_format: 'number'): number[]
-  format(_format: 'float'): number[]
+  format(_format: 'float'): RGBAFloat[]
   format(_format: 'rgba'): RGBA[]
-  format(format: PaletteFormat) {
+  format(_format?: 'cssHex'): string[]
+  format(format: PaletteFormat = 'cssHex') {
     return this.colors.map(rgba => convertRGBA(rgba, format))
   }
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -15,6 +15,7 @@ class Palette {
     this.colors = colors
   }
 
+  /** Convert this palette into a specified format */
   format(_format: 'cssHex'): string[]
   format(_format: 'cssRGBA'): string[]
   format(_format: 'number'): number[]
@@ -22,6 +23,11 @@ class Palette {
   format(_format: 'rgba'): RGBA[]
   format(format: PaletteFormat) {
     return this.colors.map(rgba => convertRGBA(rgba, format))
+  }
+
+  /** Get the number of colors in this palette */
+  get length() {
+    return this.colors.length
   }
 }
 
@@ -32,7 +38,7 @@ class Palette {
  * @param {PaletteFormat} options.format The format of the palette colors.
  * @returns {Palette} The generated palette.
  */
-export const createPalette = ({ map = 'viridis', steps = 10 }: CreatePaletteOptions): Palette => {
+export const createPalette = ({ map = 'viridis', steps = 10 }: CreatePaletteOptions = {}): Palette => {
   // If passed a map name, index from built-in color maps
   const colorMap: ColorMap = typeof map === 'string' ? maps[map] : map
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,13 +1,28 @@
 import maps, { ColorMap, MapKey } from './maps'
 import { hexColorToRGBA, lerpRGBA, RGBA } from './util'
 
-export type Palette = string[] | RGBA[] | number[]
 export type ColorMapInput = MapKey | ColorMap
 export type PaletteFormat = 'float' | 'rgba' | 'cssHex' | 'cssRGBA' | 'number'
 type CreatePaletteOptions = {
   map?: ColorMapInput,
   steps?: number,
-  format?: PaletteFormat
+}
+
+class Palette {
+  private readonly colors: RGBA[]
+
+  constructor(colors: RGBA[]) {
+    this.colors = colors
+  }
+
+  format(_format: 'cssHex'): string[]
+  format(_format: 'cssRGBA'): string[]
+  format(_format: 'number'): number[]
+  format(_format: 'float'): number[]
+  format(_format: 'rgba'): RGBA[]
+  format(format: PaletteFormat) {
+    return this.colors.map(rgba => convertRGBA(rgba, format))
+  }
 }
 
 /**
@@ -17,7 +32,7 @@ type CreatePaletteOptions = {
  * @param {PaletteFormat} options.format The format of the palette colors.
  * @returns {Palette} The generated palette.
  */
-export const createPalette = ({ map = 'viridis', steps = 10, format = 'cssHex' }: CreatePaletteOptions = {}): Palette => {
+export const createPalette = ({ map = 'viridis', steps = 10 }: CreatePaletteOptions): Palette => {
   // If passed a map name, index from built-in color maps
   const colorMap: ColorMap = typeof map === 'string' ? maps[map] : map
 
@@ -57,9 +72,8 @@ export const createPalette = ({ map = 'viridis', steps = 10, format = 'cssHex' }
     return Array.from({ length: numSteps }, (_, j) => lerpRGBA(fromColor, toColor, j / numSteps))
   })
 
-  // Convert to desired format
-  const colors = colorsRGBA.map(rgba => convertRGBA(rgba, format)) as Palette
-  return colors
+  // Return palette object
+  return new Palette(colorsRGBA)
 }
 
 /**

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -1,4 +1,5 @@
 export type RGBA = [number, number, number, number]
+export type RGBAFloat = [number, number, number, number]
 
 export const lerp = (a: number, b: number, t: number): number =>
   a + (b-a) * t

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -22,7 +22,7 @@ describe('convertRGBA', () => {
 
 describe('createPalette', () => {
   it('creates the correct palette using default arguments', () => {
-    expect(createPalette())
+    expect(createPalette().format('cssHex'))
       .toStrictEqual(['#440154FF','#472C7AFF','#3B518BFF','#2C718EFF','#27818EFF','#21908DFF','#27AD81FF','#5CC863FF','#AADC32FF','#FDE725FF'])
   })
 
@@ -33,17 +33,17 @@ describe('createPalette', () => {
   })
 
   it('creates the correct palette', () => {
-    expect(createPalette({ map: 'jet', steps: 5 }))
+    expect(createPalette({ map: 'jet', steps: 5 }).format('cssHex'))
       .toStrictEqual(['#000083FF','#003CAAFF','#05FFFFFF','#FFFF00FF','#800000FF'])
   })
 
   it('correctly interpolates alpha', () => {
-    expect(createPalette({ map: 'alpha', steps: 5 }))
+    expect(createPalette({ map: 'alpha', steps: 5 }).format('cssHex'))
       .toStrictEqual(['#FFFFFF00','#FFFFFF40','#FFFFFF80','#FFFFFFBF','#FFFFFFFF'])
   })
 
   it('returns the correct color format', () => {
-    expect(createPalette({ map: 'plasma', steps: 5, format: 'number' }))
+    expect(createPalette({ map: 'plasma', steps: 5 }).format('number'))
       .toStrictEqual([0x0D0887FF,0x7D03A8FF,0xCB4679FF,0xF89441FF,0xF0F921FF])
   })
 
@@ -51,13 +51,11 @@ describe('createPalette', () => {
     expect(createPalette({
       map: [[0, 0xFEAC5EFF],[0.5, 0xC779D0FF],[1, 0x4BC0C8FF]],
       steps: 5,
-      format: 'number',
-    })).toStrictEqual([0xFEAC5EFF,0xE39397FF,0xC779D0FF,0x899DCCFF,0x4BC0C8FF])
+    }).format('number')).toStrictEqual([0xFEAC5EFF,0xE39397FF,0xC779D0FF,0x899DCCFF,0x4BC0C8FF])
 
     expect(createPalette({
       map: [[0, [38, 83, 43, 255]],[0.25, [57, 158, 90, 255]],[0.5, [90, 188, 185, 255]],[0.75, [99, 226, 198, 255]],[1, [110, 249, 245, 255]]],
       steps: 5,
-      format: 'number',
-    })).toStrictEqual([0x26532BFF,0x399E5AFF,0x5ABCB9FF,0x63E2C6FF,0x6EF9F5FF])
+    }).format('number')).toStrictEqual([0x26532BFF,0x399E5AFF,0x5ABCB9FF,0x63E2C6FF,0x6EF9F5FF])
   })
 })


### PR DESCRIPTION
This removes the `format` option when creating a palette in favour of calling `.format()` on a returned palette object. The main benefit of this approach is that the return type from .format() is guaranteed and will vary based on the input argument. It also allows the creation of a palette once before using it in several formats later.

For example, the new example would be
```ts
import { createPalette } from 'hue-map'

const myPalette = createPalette({
  map: 'viridis',
  steps: 3,
})

console.log(myPalette.format('cssHex'))
// --> ['#440154FF', '#21908DFF', '#FDE725FF']
```